### PR TITLE
Replace Matrix#row_count with Matrix#row_size

### DIFF
--- a/lib/iruby/display.rb
+++ b/lib/iruby/display.rb
@@ -182,7 +182,7 @@ module IRuby
 
       type { Matrix }
       format 'text/latex' do |obj|
-        LaTeX.matrix(obj, obj.row_count, obj.column_count)
+        LaTeX.matrix(obj, obj.row_size, obj.column_count)
       end
       format 'text/html' do |obj|
         HTML.table(obj.to_a)


### PR DESCRIPTION
Currently Matrix latex output does not work with mri ruby 1.9.3

Example

```ruby
require 'matrix'
Matrix[[1,0,0], [0,1,0], [0,0,1]]
```

Will break with the following callstack:
 
```
Kernel died: undefined method `row_count' for Matrix.empty(0, 0):Matrix
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:185:in `block in <module:Registry>'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:108:in `call'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:108:in `render'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:64:in `block in render'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:63:in `each'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:63:in `render'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/display.rb:24:in `display'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/kernel.rb:71:in `display'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/kernel.rb:130:in `execute_request'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/kernel.rb:62:in `run'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/command.rb:30:in `run_kernel'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/lib/iruby/command.rb:16:in `run'
/home/zorbash/.gem/ruby/1.9.3/gems/iruby-0.1.13/bin/iruby:6:in `<top (required)>'
/home/zorbash/.gem/ruby/1.9.3/bin/iruby:23:in `load'
/home/zorbash/.gem/ruby/1.9.3/bin/iruby:23:in `<main>'
```

To fix it `Matrix#row_size` is used instead, which is present for RUBY_VERSION >= 1.8.7